### PR TITLE
Revert "Use inline links for festival list (#19)"

### DIFF
--- a/.github/workflows/lint_build.yml
+++ b/.github/workflows/lint_build.yml
@@ -1,7 +1,6 @@
 name: Build image
 
 on:
-  pull_request:
   push:
     branches:
       - '!master'

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ festival.db
 .idea/
 *.iml
 festival_bot/__pycache__/
-.venv/

--- a/festival_bot/models.py
+++ b/festival_bot/models.py
@@ -31,13 +31,8 @@ class Festival(peewee.Model):
         # noinspection PyUnresolvedReferences
         end = self.end.strftime(self.date_format)
 
-        link = self.link
-        if link:
-            name = f"[{self.name}]({link})"
-        else:
-            name = self.name
-
-        return f"{name} ({start} - {end})"
+        link = f" {self.link}" if self.link else ""
+        return f"{self.name} ({start} - {end}){link}"
 
 
 class User(peewee.Model):

--- a/main.py
+++ b/main.py
@@ -3,7 +3,6 @@ from typing import TypeVar, Type, Optional
 
 import peewee
 from telegram import Update
-from telegram.constants import ParseMode
 from telegram.ext import Application, ContextTypes, CommandHandler
 
 from festival_bot import required_env, init_db, User, Festival, FestivalAttendee
@@ -36,7 +35,7 @@ async def users(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
 async def festivals(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
     msg = list_message_for_model(Festival, order_by_field=Festival.start)
 
-    await update.message.reply_text(msg, disable_web_page_preview=True, parse_mode=ParseMode.MARKDOWN_V2)
+    await update.message.reply_text(msg, disable_web_page_preview=True)
 
 
 @command
@@ -73,7 +72,7 @@ async def attend(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
         except peewee.DoesNotExist:
             msg = f"{festival_query} was not found in festivals (execute `/festivals` to list available festivals)"
 
-    await update.message.reply_text(msg, disable_web_page_preview=True, parse_mode=ParseMode.MARKDOWN_V2)
+    await update.message.reply_text(msg, disable_web_page_preview=True)
 
 
 @command
@@ -121,7 +120,7 @@ async def add_festival(update: Update, _: ContextTypes.DEFAULT_TYPE) -> None:
         else:
             msg = f"{festival} already exists"
 
-    await update.message.reply_text(msg, disable_web_page_preview=True, parse_mode=ParseMode.MARKDOWN_V2)
+    await update.message.reply_text(msg, disable_web_page_preview=True)
 
 
 def main(token: str) -> None:


### PR DESCRIPTION
This reverts commit 04759ee407776c7ff93deee56cf7b424a610cd3b.

This breaks due to the date being enclosed by parentheses:

```
telegram.error.BadRequest: Can't parse entities: character '(' is reserved and must be escaped with the preceding '\'
```