### PR TITLE
Move database accesses into festival_bot/commands

### DIFF
--- a/festival_bot/commands.py
+++ b/festival_bot/commands.py
@@ -1,0 +1,48 @@
+from datetime import datetime
+from typing import Tuple, Optional, Type
+
+import peewee
+# noinspection PyPackageRequirements
+import telegram
+
+from . import User, Festival, FestivalAttendee
+from .utils import list_message_for_model
+
+
+def get_or_create(model: Type[peewee.Model], **kwargs):
+    return model.get_or_create(**kwargs)
+
+
+def login(user: telegram.User):
+    return get_or_create(User, telegram_id=user.id, name=user.full_name)
+
+
+def users() -> str:
+    return list_message_for_model(User)
+
+
+def festivals() -> str:
+    return list_message_for_model(Festival, order_by_field=Festival.start)
+
+
+def add_festival(name: str, start: datetime, end: datetime, link: Optional[str]) -> Tuple[Festival, bool]:
+    return get_or_create(Festival, name=name, start=start, end=end, link=link)
+
+
+def get_festival(festival_query) -> Festival:
+    return Festival.get(Festival.name ** festival_query)
+
+
+def get_festival_attendee(*, festival: Optional[Festival], user: Optional[telegram.User]):
+    if user:
+        attendee = FestivalAttendee.get_for_user(user.id)
+    elif festival:
+        attendee = FestivalAttendee.get_for_festival(festival.get_id())
+    else:
+        raise ValueError("either `festival` or `user` needs to be set")
+
+    return attendee
+
+
+def attend(festival: Festival, user: telegram.User) -> Tuple[FestivalAttendee, bool]:
+    return get_or_create(FestivalAttendee, festival_id=festival.get_id(), telegram_id=user.id)

--- a/festival_bot/utils.py
+++ b/festival_bot/utils.py
@@ -1,6 +1,8 @@
 import os
 
-from typing import TypeVar, Callable
+from typing import TypeVar, Callable, Type, Optional
+
+import peewee
 
 T = TypeVar("T")
 
@@ -18,3 +20,16 @@ def required_env(key: str, conversion_func: Callable[[str], T] = str) -> T:
         return conversion_func(os.environ.get(key))
 
     raise ValueError(f"`{key}` not found in environment")
+
+
+def list_message_for_model(model: Type[peewee.Model], delimiter: str = "\n", empty_message: str = "Nothing here",
+                           order_by_field: Optional[peewee.Field] = None) -> str:
+    results = model.select()
+    if order_by_field:
+        results = results.order_by(order_by_field)
+
+    msg = delimiter.join(map(str, results))
+    if not results:
+        msg = empty_message
+
+    return msg


### PR DESCRIPTION
This simplifies the re-using of functionality in other places in the code (e.g. login via decorator, see #5)

This also simplifies adding error-handling or similar to all database accesses simultaneously